### PR TITLE
feat: add share button to navbar

### DIFF
--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -1,7 +1,14 @@
 <script setup lang="ts">
+import { useClipboard } from '@vueuse/core'
 import * as monaco from 'monaco-editor'
 import { dark } from '../composables/dark'
 import { cmd, defaultFiles, files } from '../composables/state'
+
+const { copy, copied } = useClipboard({ copiedDuring: 2000 })
+
+function share() {
+  copy(location.href)
+}
 
 function reset() {
   if (
@@ -22,6 +29,13 @@ function reset() {
 
 <template>
   <div flex self-end gap1 border rounded-full>
+    <button title="Share" nav-button @click="share">
+      <div
+        :class="copied ? 'i-ri:check-line text-green' : 'i-ri:share-line'"
+        text-2xl
+      />
+    </button>
+
     <button title="Start Over" nav-button @click="reset">
       <div i-ri:refresh-line text-2xl />
     </button>


### PR DESCRIPTION
Closes #7

## Summary

- Add a "Share" button as the first icon in the navbar toolbar
- Clicking the button copies the current URL (which already contains the encoded editor state) to the clipboard
- Shows a green checkmark icon for 2 seconds as feedback, then reverts to the share icon
- Uses the same `nav-button` style and `@vueuse/core` `useClipboard` composable already used in the project

## Demo

https://github.com/younggglcy/typescript-go-playground/releases/download/share-btn-demo/share-btn-demo.mp4

## Details

- Only `NavBar.vue` is modified (14 lines added)
- No new dependencies — reuses existing `@vueuse/core` and Remixicon (`ri:share-line`, `ri:check-line`)
- Follows the same copied-feedback pattern as the output pane's copy button in `App.vue`